### PR TITLE
Breaking changes: use load_boost.h instead of load_boost_git.h

### DIFF
--- a/cpp/notebooks/cpp_pcl-1.10.ipynb
+++ b/cpp/notebooks/cpp_pcl-1.10.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#include \"load_boost_git.h\"\n",
+    "#include \"load_boost.h\"\n",
     "#include \"load_eigen3.h\"\n",
     "#include \"load_pcl_common-1.10.h\""
    ]

--- a/cpp/notebooks/cpp_pcl-1.8.ipynb
+++ b/cpp/notebooks/cpp_pcl-1.8.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#include \"load_boost_git.h\"\n",
+    "#include \"load_boost.h\"\n",
     "#include \"load_eigen3.h\"\n",
     "#include \"load_pcl_common-1.8.h\""
    ]

--- a/cpp/notebooks/cpp_ros_async_publisher.ipynb
+++ b/cpp/notebooks/cpp_ros_async_publisher.ipynb
@@ -54,7 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#include \"load_boost_git.h\"\n",
+    "#include \"load_boost.h\"\n",
     "#include \"load_roscpp.h\""
    ]
   },

--- a/cpp/notebooks/cpp_ros_async_subscriber.ipynb
+++ b/cpp/notebooks/cpp_ros_async_subscriber.ipynb
@@ -54,7 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#include \"load_boost_git.h\"\n",
+    "#include \"load_boost.h\"\n",
     "#include \"load_roscpp.h\""
    ]
   },

--- a/cpp/notebooks/cpp_ros_param_widget.ipynb
+++ b/cpp/notebooks/cpp_ros_param_widget.ipynb
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#include \"load_boost_git.h\"\n",
+    "#include \"load_boost.h\"\n",
     "#include \"load_roscpp.h\""
    ]
   },

--- a/cpp/notebooks/cpp_ros_publisher.ipynb
+++ b/cpp/notebooks/cpp_ros_publisher.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#include \"load_boost_git.h\"\n",
+    "#include \"load_boost.h\"\n",
     "#include \"load_roscpp.h\""
    ]
   },

--- a/cpp/notebooks/cpp_ros_subscriber.ipynb
+++ b/cpp/notebooks/cpp_ros_subscriber.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#include \"load_boost_git.h\"\n",
+    "#include \"load_boost.h\"\n",
     "#include \"load_roscpp.h\""
    ]
   },

--- a/cpp/scripts/generate_cling_boost.py
+++ b/cpp/scripts/generate_cling_boost.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
 Scripts that generate required `#pragma cling` for loading the boost library in the C++ Jupyter Notebook
-using the git source code
+using the conda env
 
 Usage:
-generate_cling_boost.py /path/to/boost
+generate_cling_boost.py
 """
 import argparse
 from pathlib import Path
@@ -19,18 +19,19 @@ def main():
     boost_conda_path = Path(os.environ['CONDA_PREFIX'] + "/include")
     path = boost_conda_path / "boost"
     if not path.exists():
-        print("[ERROR] Failed to find path", path, ". Are you sure you put the correct boost path?")
+        print("[ERROR] Failed to find boost. Please install via conda install -c conda-forge boost")
         from sys import exit
         exit(1)
 
     include_dirs = path.glob("**/include")
-    with open("load_boost_git.h", "w") as f:
+    filename = "load_boost.h"
+    with open(filename, "w") as f:
         f.write("#pragma once\n\n")
         for inc_dir in include_dirs:
             f.write('#pragma cling add_include_path("%s")\n' % str(inc_dir))
 
     os.makedirs(args.target_dir, exist_ok=True)
-    print("Files written to", "%s/load_boost_git.h"%args.target_dir)
+    print("Files written to", "%s/%s"%(args.target_dir, filename))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
... since it's not from git anymore
Notifying @kunaltyagi @Apurv354 @kota-rr @DicksonWu654 since it might be a breaking changes 
I've changed `load_boost_git.h` to `load_boost.h` of all the notebook in current repo


Also added instruction to install boost when boost isn't found in conda env.

